### PR TITLE
Initial Expo scaffold

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Example environment variables
+FIREBASE_API_KEY=your_api_key
+FIREBASE_AUTH_DOMAIN=your_auth_domain
+FIREBASE_PROJECT_ID=your_project_id
+FIREBASE_STORAGE_BUCKET=your_storage_bucket
+FIREBASE_MESSAGING_SENDER_ID=your_messaging_sender_id
+FIREBASE_APP_ID=your_app_id
+FIREBASE_MEASUREMENT_ID=your_measurement_id
+FCM_SERVICE_KEY=your_fcm_service_key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: yarn install --frozen-lockfile
+      - run: yarn test --coverage
+      - run: npx expo eas build --profile preview --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
+          cache: 'yarn'
       - run: yarn install --frozen-lockfile
       - run: yarn test --coverage
       - run: npx expo eas build --profile preview --non-interactive
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+
+  release:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+      - run: yarn install --frozen-lockfile
+      - run: npx expo eas build --profile production --non-interactive
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,11 @@
+import Navigation from './app/navigation';
+import './app/lib/i18n';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+
+export default function App() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <Navigation />
+    </GestureHandlerRootView>
+  );
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+# Islamic Center Mobile App
+
+This project is a React Native application built with Expo and Firebase. It provides prayer times, live streaming, events, and local reminders for an Islamic center.
+
+## Requirements
+- Node.js 18+
+- Yarn
+- Expo CLI
+
+## Setup
+1. Copy `.env.example` to `.env` and fill in the Firebase configuration values.
+2. Install dependencies:
+   ```sh
+   yarn install
+   ```
+3. Run the app in development mode:
+   ```sh
+   expo start
+   ```
+
+## Running locally
+To run the app on a simulator or device, ensure Expo CLI is installed and run `expo start` from the project root.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,18 @@ This project is a React Native application built with Expo and Firebase. It prov
    ```sh
    yarn install
    ```
-3. Run the app in development mode:
+3. Run unit tests:
+   ```sh
+   yarn test
+   ```
+4. Run the app in development mode:
    ```sh
    expo start
    ```
 
 ## Running locally
 To run the app on a simulator or device, ensure Expo CLI is installed and run `expo start` from the project root.
+
+## Next Steps
+- **Sprint 2**: implement live streaming and FCM topic subscription.
+- **Sprint 3**: build events calendar and polish i18n/RTL support.

--- a/__tests__/TimetableScreen.test.tsx
+++ b/__tests__/TimetableScreen.test.tsx
@@ -1,0 +1,7 @@
+import { render } from '@testing-library/react-native';
+import TimetableScreen from '../app/screens/TimetableScreen';
+
+test('renders TimetableScreen', () => {
+  const { toJSON } = render(<TimetableScreen />);
+  expect(toJSON()).toBeTruthy();
+});

--- a/__tests__/notifications.test.ts
+++ b/__tests__/notifications.test.ts
@@ -1,0 +1,19 @@
+import * as Notifications from 'expo-notifications';
+import { schedulePrayerNotifications } from '../app/services/notifications';
+import { PrayerTime } from '../app/lib/types';
+
+jest.mock('expo-notifications');
+
+const mockSchedule = Notifications.scheduleNotificationAsync as jest.Mock;
+
+beforeEach(() => {
+  mockSchedule.mockClear();
+});
+
+test('schedules two notifications per prayer', async () => {
+  const times: PrayerTime[] = [
+    { prayer: 'Fajr', adhan: new Date(), iqamah: new Date() },
+  ];
+  await schedulePrayerNotifications(times);
+  expect(mockSchedule).toHaveBeenCalledTimes(2);
+});

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,0 +1,25 @@
+import 'dotenv/config';
+import { ExpoConfig, ConfigContext } from '@expo/config';
+
+export default ({ config }: ConfigContext): ExpoConfig => ({
+  name: 'APP_NAME', // TODO: replace with actual app name
+  slug: 'app-name',
+  version: '1.0.0',
+  orientation: 'portrait',
+  icon: './assets/icon.png',
+  userInterfaceStyle: 'automatic',
+  extra: {
+    FCM_SERVICE_KEY: process.env.FCM_SERVICE_KEY,
+  },
+  ios: {
+    bundleIdentifier: 'BUNDLE_ID', // TODO: replace with actual bundle id
+    supportsTablet: true,
+  },
+  android: {
+    package: 'BUNDLE_ID', // TODO: replace with actual bundle id
+    adaptiveIcon: {
+      foregroundImage: './assets/adaptive-icon.png',
+      backgroundColor: '#FFFFFF',
+    },
+  },
+});

--- a/app.config.ts
+++ b/app.config.ts
@@ -1,3 +1,4 @@
+import 'expo-dev-client';
 import 'dotenv/config';
 import { ExpoConfig, ConfigContext } from '@expo/config';
 
@@ -9,6 +10,13 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
   icon: './assets/icon.png',
   userInterfaceStyle: 'automatic',
   extra: {
+    firebase: {
+      apiKey: process.env.FIREBASE_API_KEY,
+      authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+      projectId: process.env.FIREBASE_PROJECT_ID,
+      messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+      appId: process.env.FIREBASE_APP_ID,
+    },
     FCM_SERVICE_KEY: process.env.FCM_SERVICE_KEY,
   },
   ios: {

--- a/app/components/PrayerCard.tsx
+++ b/app/components/PrayerCard.tsx
@@ -1,0 +1,12 @@
+import { View, Text } from 'react-native';
+import { PrayerTime } from '../lib/types';
+
+export default function PrayerCard({ prayer }: { prayer: PrayerTime }) {
+  return (
+    <View className="p-4 mb-2 bg-white rounded-lg shadow">
+      <Text className="font-bold text-lg">{prayer.prayer}</Text>
+      <Text>Adhan: {prayer.adhan}</Text>
+      <Text>Iqamah: {prayer.iqamah}</Text>
+    </View>
+  );
+}

--- a/app/hooks/usePrayerTimes.ts
+++ b/app/hooks/usePrayerTimes.ts
@@ -2,9 +2,10 @@ import { useEffect, useState, useCallback } from 'react';
 import { collection, doc, onSnapshot } from 'firebase/firestore';
 import { firestore } from '../services/firebase';
 import { PrayerTimes } from '../lib/types';
+import { schedulePrayerNotifications } from '../services/notifications';
 
 export function usePrayerTimes(dateKey: string) {
-  const [data, setData] = useState<PrayerTimes[] | null>(null);
+  const [data, setData] = useState<PrayerTimes | null>(null);
   const [loading, setLoading] = useState(true);
 
   const refetch = useCallback(() => {
@@ -12,6 +13,9 @@ export function usePrayerTimes(dateKey: string) {
     return onSnapshot(docRef, (docSnap) => {
       setData(docSnap.data()?.times || []);
       setLoading(false);
+      if (docSnap.data()?.times) {
+        schedulePrayerNotifications(docSnap.data().times);
+      }
     });
   }, [dateKey]);
 

--- a/app/hooks/usePrayerTimes.ts
+++ b/app/hooks/usePrayerTimes.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState, useCallback } from 'react';
+import { collection, doc, onSnapshot } from 'firebase/firestore';
+import { firestore } from '../services/firebase';
+import { PrayerTimes } from '../lib/types';
+
+export function usePrayerTimes(dateKey: string) {
+  const [data, setData] = useState<PrayerTimes[] | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const refetch = useCallback(() => {
+    const docRef = doc(collection(firestore, 'prayerTimes'), dateKey);
+    return onSnapshot(docRef, (docSnap) => {
+      setData(docSnap.data()?.times || []);
+      setLoading(false);
+    });
+  }, [dateKey]);
+
+  useEffect(() => {
+    const unsubscribe = refetch();
+    return unsubscribe;
+  }, [refetch]);
+
+  return { data, loading, refetch };
+}

--- a/app/lib/i18n.ts
+++ b/app/lib/i18n.ts
@@ -1,0 +1,16 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+
+const resources = {
+  en: { translation: {} },
+  ar: { translation: {} },
+};
+
+i18n.use(initReactI18next).init({
+  resources,
+  lng: 'en',
+  fallbackLng: 'en',
+  interpolation: { escapeValue: false },
+});
+
+export default i18n;

--- a/app/lib/prayerSchema.ts
+++ b/app/lib/prayerSchema.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod';
+
+export const PrayerTimeSchema = z.object({
+  prayer: z.string(),
+  adhan: z.string(),
+  iqamah: z.string(),
+});
+
+export const PrayerTimesSchema = z.array(PrayerTimeSchema);
+export type PrayerTimes = z.infer<typeof PrayerTimesSchema>;

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -1,0 +1,7 @@
+export interface PrayerTime {
+  prayer: string;
+  adhan: string;
+  iqamah: string;
+}
+
+export type PrayerTimes = PrayerTime[];

--- a/app/lib/types.ts
+++ b/app/lib/types.ts
@@ -1,7 +1,7 @@
 export interface PrayerTime {
   prayer: string;
-  adhan: string;
-  iqamah: string;
+  adhan: Date;
+  iqamah: Date;
 }
 
 export type PrayerTimes = PrayerTime[];

--- a/app/navigation/TabNavigator.tsx
+++ b/app/navigation/TabNavigator.tsx
@@ -1,0 +1,20 @@
+import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import HomeScreen from '../screens/HomeScreen';
+import TimetableScreen from '../screens/TimetableScreen';
+import LiveScreen from '../screens/LiveScreen';
+import EventsScreen from '../screens/EventsScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+
+const Tab = createBottomTabNavigator();
+
+export default function TabNavigator() {
+  return (
+    <Tab.Navigator>
+      <Tab.Screen name="Home" component={HomeScreen} />
+      <Tab.Screen name="Timetable" component={TimetableScreen} />
+      <Tab.Screen name="Live" component={LiveScreen} />
+      <Tab.Screen name="Events" component={EventsScreen} />
+      <Tab.Screen name="Settings" component={SettingsScreen} />
+    </Tab.Navigator>
+  );
+}

--- a/app/navigation/index.tsx
+++ b/app/navigation/index.tsx
@@ -1,0 +1,10 @@
+import { NavigationContainer } from '@react-navigation/native';
+import TabNavigator from './TabNavigator';
+
+export default function Navigation() {
+  return (
+    <NavigationContainer>
+      <TabNavigator />
+    </NavigationContainer>
+  );
+}

--- a/app/screens/EventsScreen.tsx
+++ b/app/screens/EventsScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function EventsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text>Events Screen</Text>
+    </View>
+  );
+}

--- a/app/screens/HomeScreen.tsx
+++ b/app/screens/HomeScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function HomeScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text>Home Screen</Text>
+    </View>
+  );
+}

--- a/app/screens/LiveScreen.tsx
+++ b/app/screens/LiveScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function LiveScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text>Live Screen</Text>
+    </View>
+  );
+}

--- a/app/screens/SettingsScreen.tsx
+++ b/app/screens/SettingsScreen.tsx
@@ -1,0 +1,9 @@
+import { View, Text } from 'react-native';
+
+export default function SettingsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <Text>Settings Screen</Text>
+    </View>
+  );
+}

--- a/app/screens/TimetableScreen.tsx
+++ b/app/screens/TimetableScreen.tsx
@@ -1,0 +1,25 @@
+import { View, FlatList, RefreshControl } from 'react-native';
+import { useCallback } from 'react';
+import { usePrayerTimes } from '../hooks/usePrayerTimes';
+import PrayerCard from '../components/PrayerCard';
+import { format } from 'date-fns';
+
+export default function TimetableScreen() {
+  const dateKey = format(new Date(), 'yyyyMMdd');
+  const { data, loading, refetch } = usePrayerTimes(dateKey);
+
+  const onRefresh = useCallback(() => {
+    refetch();
+  }, [refetch]);
+
+  return (
+    <View className="flex-1 p-4">
+      <FlatList
+        data={data || []}
+        keyExtractor={(item) => item.prayer}
+        renderItem={({ item }) => <PrayerCard prayer={item} />}
+        refreshControl={<RefreshControl refreshing={loading} onRefresh={onRefresh} />}
+      />
+    </View>
+  );
+}

--- a/app/services/firebase.ts
+++ b/app/services/firebase.ts
@@ -1,17 +1,11 @@
-import { initializeApp } from 'firebase/app';
+import { FirebaseOptions, initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
+import Constants from 'expo-constants';
 
-const firebaseConfig = {
-  apiKey: process.env.FIREBASE_API_KEY, // TODO: set via env
-  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
-  projectId: process.env.FIREBASE_PROJECT_ID,
-  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
-  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
-  appId: process.env.FIREBASE_APP_ID,
-  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
-};
+const firebaseConfig = Constants.expoConfig?.extra?.firebase as FirebaseOptions;
 
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
 export const firestore = getFirestore(app);
+export default app;

--- a/app/services/firebase.ts
+++ b/app/services/firebase.ts
@@ -1,0 +1,17 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY, // TODO: set via env
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const firestore = getFirestore(app);

--- a/app/services/notifications.ts
+++ b/app/services/notifications.ts
@@ -1,0 +1,17 @@
+import * as Notifications from 'expo-notifications';
+import { PrayerTimes } from '../lib/types';
+
+export async function requestPermissionsAsync() {
+  const settings = await Notifications.getPermissionsAsync();
+  if (!settings.granted) {
+    await Notifications.requestPermissionsAsync();
+  }
+}
+
+export async function schedulePrayerNotifications(prayerTimes: PrayerTimes[]) {
+  // TODO: schedule notifications 5 min before adhan and 1 min before iqamah
+}
+
+export async function cancelAllPrayerNotifications() {
+  await Notifications.cancelAllScheduledNotificationsAsync();
+}

--- a/app/services/notifications.ts
+++ b/app/services/notifications.ts
@@ -1,15 +1,24 @@
 import * as Notifications from 'expo-notifications';
 import { PrayerTimes } from '../lib/types';
 
-export async function requestPermissionsAsync() {
-  const settings = await Notifications.getPermissionsAsync();
-  if (!settings.granted) {
+export async function requestNotifPermissions() {
+  const { status } = await Notifications.getPermissionsAsync();
+  if (status !== 'granted') {
     await Notifications.requestPermissionsAsync();
   }
 }
-
 export async function schedulePrayerNotifications(prayerTimes: PrayerTimes[]) {
-  // TODO: schedule notifications 5 min before adhan and 1 min before iqamah
+  await cancelAllPrayerNotifications();
+  prayerTimes.forEach((t) => {
+    Notifications.scheduleNotificationAsync({
+      content: { title: t.prayer, body: 'Adh\u0101n in 5 min' },
+      trigger: new Date(t.adhan.getTime() - 5 * 60 * 1000),
+    });
+    Notifications.scheduleNotificationAsync({
+      content: { title: t.prayer, body: 'Iq\u0101mah in 1 min' },
+      trigger: new Date(t.iqamah.getTime() - 60 * 1000),
+    });
+  });
 }
 
 export async function cancelAllPrayerNotifications() {

--- a/firebase.js
+++ b/firebase.js
@@ -1,0 +1,18 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+
+const firebaseConfig = {
+  apiKey: process.env.FIREBASE_API_KEY, // TODO: set via env
+  authDomain: process.env.FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.FIREBASE_PROJECT_ID,
+  storageBucket: process.env.FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.FIREBASE_APP_ID,
+  measurementId: process.env.FIREBASE_MEASUREMENT_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export const firestore = getFirestore(app);
+export default app;

--- a/firebase.js
+++ b/firebase.js
@@ -1,9 +1,12 @@
-import { initializeApp } from 'firebase/app';
+import { FirebaseOptions, initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
 import { getFirestore } from 'firebase/firestore';
+import dotenv from 'dotenv';
 
-const firebaseConfig = {
-  apiKey: process.env.FIREBASE_API_KEY, // TODO: set via env
+dotenv.config();
+
+const firebaseConfig: FirebaseOptions = {
+  apiKey: process.env.FIREBASE_API_KEY,
   authDomain: process.env.FIREBASE_AUTH_DOMAIN,
   projectId: process.env.FIREBASE_PROJECT_ID,
   storageBucket: process.env.FIREBASE_STORAGE_BUCKET,

--- a/firebase/firestore.rules
+++ b/firebase/firestore.rules
@@ -1,0 +1,6 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    // TODO: define security rules
+  }
+}

--- a/firebase/functions/index.js
+++ b/firebase/functions/index.js
@@ -1,0 +1,1 @@
+// TODO: Add cloud functions here

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'react-native',
+  testEnvironment: 'jsdom',
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,6 @@
 module.exports = {
-  preset: 'react-native',
-  testEnvironment: 'jsdom',
+  preset: 'jest-expo',
+  transform: { '^.+\\.tsx?$': 'ts-jest' },
+  setupFilesAfterEnv: ['@testing-library/jest-native/extend-expect'],
+  testPathIgnorePatterns: ['/e2e/'],
 };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "lcic-mobile-app",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "test": "jest"
+  },
+  "dependencies": {
+    "expo": "^50.0.0",
+    "react": "18.2.0",
+    "react-native": "0.75.0",
+    "firebase": "^12.0.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.0",
+    "@types/react-native": "^0.75.0",
+    "jest": "^29.0.0",
+    "react-native-testing-library": "^12.1.5",
+    "typescript": "^5.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "node_modules/expo/AppEntry.js",
   "scripts": {
     "start": "expo start",
-    "test": "jest"
+    "test": "jest --runInBand",
+    "test:watch": "jest --watchAll",
+    "lint": "eslint . --ext .js,.ts,.tsx"
   },
   "dependencies": {
     "expo": "^50.0.0",
@@ -16,8 +18,11 @@
   "devDependencies": {
     "@types/react": "^18.0.0",
     "@types/react-native": "^0.75.0",
+    "@testing-library/jest-native": "^5.4.2",
+    "@testing-library/react-native": "^12.1.5",
     "jest": "^29.0.0",
-    "react-native-testing-library": "^12.1.5",
+    "jest-expo": "^50.0.0",
+    "ts-jest": "^29.0.0",
     "typescript": "^5.0.0"
   }
 }

--- a/scripts/seedPrayerTimes.ts
+++ b/scripts/seedPrayerTimes.ts
@@ -1,0 +1,18 @@
+import { format } from 'date-fns';
+import { collection, doc, setDoc } from 'firebase/firestore';
+import app, { firestore } from '../app/services/firebase';
+
+async function seed() {
+  const dateKey = format(new Date(), 'yyyyMMdd');
+  const ref = doc(collection(firestore, 'prayerTimes'), dateKey);
+  await setDoc(ref, {
+    times: [
+      { prayer: 'Fajr', adhan: new Date(), iqamah: new Date() },
+    ],
+  });
+  console.log('seeded', dateKey);
+}
+
+seed().finally(() => {
+  app.delete?.();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1,0 +1,1 @@
+# Placeholder lockfile - run yarn install to populate


### PR DESCRIPTION
## Summary
- scaffold mobile app directories with Expo
- add Firebase initialization and services
- implement navigation with a TabNavigator
- add placeholder screens and a sample hook
- configure notifications service
- setup GitHub Actions workflow and example test
- document setup steps

## Testing
- `yarn test` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6867f31f06cc832881e8741c8696b9e8